### PR TITLE
Improve Apple signature generation

### DIFF
--- a/sigger.cpp
+++ b/sigger.cpp
@@ -17,6 +17,7 @@ Optimized for Jailbroken iOS CLI
 #include <iomanip>
 #include <cstdint>
 #include <cstdlib>
+#include <utility>
 #include <sys/stat.h> // For iOS-compatible file existence check
 
 class iSig {
@@ -84,15 +85,49 @@ private:
         }
     }
 
-    // Disassemble binary
-    std::vector<uint8_t> bin_disasm(const std::vector<uint8_t> &blob, size_t off, size_t lim) {
+    // Produce formatted signature tokens for an instruction stream
+    std::string instructions_to_pattern(cs_arch arch, const cs_insn *ins, size_t cnt) {
+        std::ostringstream out;
+        for (size_t idx = 0; idx < cnt; ++idx) {
+            const cs_insn &inst = ins[idx];
+            bool wildcard = false;
+
+            if (inst.detail) {
+                if (arch == CS_ARCH_AARCH64) {
+                    const cs_arm64 &arm = inst.detail->arm64;
+                    for (uint8_t op_idx = 0; op_idx < arm.op_count; ++op_idx) {
+                        const cs_arm64_op &op = arm.operands[op_idx];
+                        if (op.type == ARM64_OP_IMM) {
+                            wildcard = true;
+                            break;
+                        }
+                        if (op.type == ARM64_OP_MEM && (op.mem.disp != 0 || op.mem.base == ARM64_REG_PC)) {
+                            wildcard = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            for (size_t b = 0; b < inst.size; ++b) {
+                if (wildcard && arch == CS_ARCH_AARCH64)
+                    out << "??";
+                else
+                    out << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(inst.bytes[b]);
+                if (!(idx == cnt - 1 && b == inst.size - 1)) out << ' ';
+            }
+        }
+        return out.str();
+    }
+
+    // Disassemble binary to Apple signature pattern
+    std::pair<std::string, std::vector<uint8_t>> bin_disasm_pattern(const std::vector<uint8_t> &blob, size_t off, size_t lim) {
         cs_arch arc;
         cs_mode mod;
         csh eng;
         cs_insn *inst;
         const uint8_t *ptr;
-        size_t len, i, lll;
-        std::vector<uint8_t> out;
+        size_t len;
 
         gettargetarch(arc, mod, blob);
         if (cs_open(arc, mod, &eng) != CS_ERR_OK) fatal("capstone fail");
@@ -101,13 +136,46 @@ private:
         len = blob.size() - off;
         size_t cnt = cs_disasm(eng, ptr, len, 0, lim, &inst);
         if (cnt == 0) fatal("disasm fail");
-        for (i = 0; i < cnt; i++)
-            for (lll = 0; lll < inst[i].size; lll++)
-                out.push_back(inst[i].bytes[lll]);
+
+        std::string pattern = instructions_to_pattern(arc, inst, cnt);
+        std::vector<uint8_t> raw;
+        for (size_t idx = 0; idx < cnt; ++idx)
+            raw.insert(raw.end(), inst[idx].bytes, inst[idx].bytes + inst[idx].size);
 
         cs_free(inst, cnt);
         cs_close(&eng);
+        return {pattern, raw};
+    }
+
+    // Parse exact hex string into bytes (no wildcards allowed)
+    std::vector<uint8_t> parse_hex_exact(const std::string &s) {
+        std::istringstream stream(s);
+        std::string token;
+        std::vector<uint8_t> out;
+        while (stream >> token) {
+            if (token.find('?') != std::string::npos) fatal("wildcards not allowed in hex input");
+            out.push_back(static_cast<uint8_t>(std::stoul(token, nullptr, 16)));
+        }
         return out;
+    }
+
+    std::string apple_signature_from_hex(const std::string &hex) {
+        std::vector<uint8_t> bytes = parse_hex_exact(hex);
+        if (bytes.empty()) fatal("hex input required");
+
+        csh eng;
+        cs_insn *inst;
+        if (cs_open(CS_ARCH_AARCH64, CS_MODE_ARM, &eng) != CS_ERR_OK) fatal("capstone fail");
+        cs_option(eng, CS_OPT_DETAIL, CS_OPT_ON);
+
+        size_t cnt = cs_disasm(eng, bytes.data(), bytes.size(), 0, 0, &inst);
+        if (cnt == 0) fatal("unable to disassemble input");
+
+        std::string pattern = instructions_to_pattern(CS_ARCH_AARCH64, inst, cnt);
+
+        cs_free(inst, cnt);
+        cs_close(&eng);
+        return pattern;
     }
 
     // Match signature to address
@@ -135,7 +203,8 @@ private:
     void helpme() {
         std::cout << clr_hdr << "usage:\n" << clr_rst;
         std::cout << clr_alt << "  ./sig bin --addr-to-sig 0xFFFF\n";
-        std::cout << "  ./sig bin --sig-to-addr " << clr_ok << "AA BB ?? CC" << clr_rst << std::endl;
+        std::cout << "  ./sig bin --sig-to-addr " << clr_ok << "AA BB ?? CC" << clr_rst << '\n';
+        std::cout << "  ./sig " << clr_ok << "--hex-to-apple" << clr_rst << " " << clr_alt << "AA BB CC" << clr_rst << std::endl;
     }
 
 public:
@@ -145,18 +214,28 @@ public:
             return;
         }
 
-        std::string pth = av[1];
-        if (!fileExists(pth)) fatal("no such file");
+        std::string first = av[1];
+        if (first == "--hex-to-apple") {
+            if (ac < 3) fatal("hex string required");
+            std::stringstream ss;
+            for (int i = 2; i < ac; ++i) ss << av[i] << ' ';
+            std::string pattern = apple_signature_from_hex(ss.str());
+            std::cout << clr_ok << "[apple]" << clr_rst << " " << pattern << std::endl;
+            return;
+        }
 
-        std::vector<uint8_t> buf = bin_load(pth);
+        if (!fileExists(first)) fatal("no such file");
+
+        std::vector<uint8_t> buf = bin_load(first);
 
         if (ac >= 4) {
             std::string flg = av[2];
             if (flg == "--addr-to-sig") {
                 size_t ofs = std::stoul(av[3], nullptr, 16);
                 if (ofs >= buf.size()) fatal("offset out of range");
-                auto sig = bin_disasm(buf, ofs, 5);
-                std::cout << "sig:\n" << bin_hex(sig) << std::endl;
+                auto [pattern, raw] = bin_disasm_pattern(buf, ofs, 5);
+                std::cout << clr_hdr << "raw:" << clr_rst << '\n' << bin_hex(raw) << std::endl;
+                std::cout << clr_ok << "apple:" << clr_rst << '\n' << pattern << std::endl;
             } else if (flg == "--sig-to-addr") {
                 std::stringstream ss;
                 for (int i = 3; i < ac; i++) ss << av[i] << ' ';


### PR DESCRIPTION
## Summary
- add instruction analysis to wildcard AArch64 immediates when emitting Apple signature patterns
- expose a CLI helper that turns raw hex strings into Apple wildcard signatures and enhance addr-to-sig output

## Testing
- g++ -std=c++17 sigger.cpp -lcapstone -o sigger *(fails: missing capstone headers in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e484f50e508327b1eb5fb5846b790c